### PR TITLE
Fix Array.to_xml so that the given :namespace is applied to every element in a array

### DIFF
--- a/lib/gyoku/array.rb
+++ b/lib/gyoku/array.rb
@@ -8,10 +8,10 @@ module Gyoku
 
     # Translates a given +array+ to XML. Accepts the XML +key+ to add the elements to,
     # whether to +escape_xml+ and an optional Hash of +attributes+.
-    def self.to_xml(array, key, escape_xml = true, attributes = {})
+    def self.to_xml(array, key, escape_xml = true, attributes = {}, options = {})
       iterate_with_xml array, attributes do |xml, item, attrs, index|
         case item
-          when ::Hash   then xml.tag!(key, attrs) { xml << Hash.to_xml(item) }
+          when ::Hash   then xml.tag!(key, attrs) { xml << Hash.to_xml(item, options) }
           when NilClass then xml.tag!(key, "xsi:nil" => "true")
           else               xml.tag!(key, attrs) { xml << XMLValue.create(item, escape_xml) }
         end

--- a/lib/gyoku/hash.rb
+++ b/lib/gyoku/hash.rb
@@ -15,7 +15,7 @@ module Gyoku
         xml_key = XMLKey.create key, options
 
         case
-          when ::Array === value  then xml << Array.to_xml(value, xml_key, escape_xml, attributes)
+          when ::Array === value  then xml << Array.to_xml(value, xml_key, escape_xml, attributes, options)
           when ::Hash === value   then xml.tag!(xml_key, attributes) { xml << Hash.to_xml(value, options) }
           when self_closing       then xml.tag!(xml_key, attributes)
           when NilClass === value then xml.tag!(xml_key, "xsi:nil" => "true")

--- a/spec/gyoku/hash_spec.rb
+++ b/spec/gyoku/hash_spec.rb
@@ -132,6 +132,16 @@ describe Gyoku::Hash do
           "<v2:third><v2:firstName>Danie</v2:firstName></v2:third>"
         )
       end
+      
+      it "should add given :namespace to every element in an array" do
+        hash = { :array => [ :first  => "Luvy", :second => "Anna" ]}
+        result = to_xml hash, :element_form_default => :qualified, :namespace => :v1
+
+        result.should include(
+          "<v1:array><v1:first>Luvy</v1:first><v1:second>Anna</v1:second></v1:array>"
+        )
+      end
+      
     end
   end
 


### PR DESCRIPTION
Hi there,

I ran into an issue where namespaces where not being applied to hash items that are arrays.  This resulted in some xml elements not including the given namespace.

Thanks,
Matt
