### PR TITLE
Deep duping hash for not affect original objects

### DIFF
--- a/lib/gyoku.rb
+++ b/lib/gyoku.rb
@@ -6,7 +6,7 @@ module Gyoku
 
     # Translates a given +hash+ with +options+ to XML.
     def xml(hash, options = {})
-      Hash.to_xml hash.dup, options
+      Hash.to_xml deep_dup(hash), options
     end
 
     # Yields this object for configuration.
@@ -17,6 +17,27 @@ module Gyoku
     # Sets the formula for converting Symbol keys.
     def convert_symbols_to(formula = nil, &block)
       XMLKey.symbol_converter = formula ? formula : block
+    end
+
+    private
+
+    def deep_dup(object)
+      case object
+      when Array
+        temp = []
+        object.each { |it| temp << deep_dup(it) }
+        temp
+      when Hash
+        temp = {}
+        object.each { |k,v| temp[k] = deep_dup(v) }
+        temp
+      else
+        begin
+          object.clone
+        rescue TypeError
+          object
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Simple problem with hashes which not duped or cloned deeply. Need some hack

Example with Savon:

``` ruby
module A
  extend self

  def base_body
    @base_data ||= \
      {
        :a => 123,
        :attributes! => {
          :a => {
            :some_attr => 321
          }
        }
      }
  end

end

savon_client.request :some_request do |soap|
  soap.body = { :b => 123, :c => A.base_body }
end

puts A.base_body
# => { :a => 123 }
```
