### PR TITLE
Gyoku generates blank attribute values if there are fewer attribute values in attributes! than elements

### DIFF
--- a/lib/gyoku/array.rb
+++ b/lib/gyoku/array.rb
@@ -37,7 +37,7 @@ module Gyoku
 
       attributes.inject({}) do |hash, (key, value)|
         value = value[index] if value.kind_of? ::Array
-        hash.merge key => value
+        value ? hash.merge(key => value) : hash
       end
     end
 

--- a/spec/gyoku/array_spec.rb
+++ b/spec/gyoku/array_spec.rb
@@ -44,6 +44,13 @@ describe Gyoku::Array do
 
       to_xml(array, "value", :escape_xml, :id => [1, 2]).should == result
     end
+
+    it "skips attribute for element without attributes if there are fewer attributes than elements" do
+      array = ["adam", "eve", "serpent"]
+      result = '<value id="1">adam</value><value id="2">eve</value><value>serpent</value>'
+
+      to_xml(array, "value", :escape_xml, :id => [1, 2]).should == result
+    end
   end
 
   def to_xml(*args)

--- a/spec/gyoku/hash_spec.rb
+++ b/spec/gyoku/hash_spec.rb
@@ -123,6 +123,12 @@ describe Gyoku::Hash do
       to_xml(hash).should == result
     end
 
+    it "skips attribute for element without attributes if there are fewer attributes than elements" do
+      hash = { :find_user => { :person => ["Lucy", "Anna", "Beth"], :attributes! => { :person => { :id => [1, 3] } } } }
+      result = '<findUser><person id="1">Lucy</person><person id="3">Anna</person><person>Beth</person></findUser>'
+      to_xml(hash).should == result
+    end
+
     it "adds attributes to self-closing tags" do
       hash = {
         "category/" => "",


### PR DESCRIPTION
If attributes! is not given for all elements, Gyoku generates the attribute with blank values.
This breaks web services which require the attribute to be unspecified or non-blank

For example:

```
hash = { :find_user => { :person => ["Lucy", "Anna", "Beth"], :attributes! => { :person => { :id => [1, 2] } } } }
Gyoku.xml(hash)
```

generates

```
<findUser><person id=\"1\">Lucy</person><person id=\"2\">Anna</person><person id=\"\">Beth</person></findUser>
```

The blank id for the last element is incorrect if web service does not require you to specify ids for new elements.
The generated xml should have been:

```
<findUser><person id=\"1\">Lucy</person><person id=\"2\">Anna</person><person>Beth</person></findUser>
```

without the blank id attribute.

Please find the fix in pull request
