### PR TITLE
uppercase convert_symbols_to formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Gyoku.xml(:lower_camel_case => "key")
 You can change the default conversion formula.
 
 ``` ruby
-Gyoku.convert_symbols_to :camelcase  # or one of [:none, :lower_camelcase]
+Gyoku.convert_symbols_to :camelcase  # or one of [:none, :lower_camelcase, :uppercase]
 
 Gyoku.xml(:camel_case => "key")
 # => "<CamelCase>key</CamelCase>"
@@ -40,10 +40,10 @@ Gyoku.xml(:camel_case => "key")
 And you can also define your own formula.
 
 ``` ruby
-Gyoku.convert_symbols_to { |key| key.upcase }
+Gyoku.convert_symbols_to { |key| key.sub(/^prefixed_/, '') }
 
-Gyoku.xml(:upcase => "key")
-# => "<UPCASE>key</UPCASE>"
+Gyoku.xml(:prefixed_attribute => "key")
+# => "<attribute>key</attribute>"
 ```
 
 Hash key Strings are not converted and may contain namespaces.

--- a/lib/gyoku/xml_key.rb
+++ b/lib/gyoku/xml_key.rb
@@ -4,10 +4,12 @@ module Gyoku
 
       CAMELCASE = lambda { |key| key.gsub(/\/(.?)/) { "::#{$1.upcase}" }.gsub(/(?:^|_)(.)/) { $1.upcase } }
       LOWER_CAMELCASE = lambda { |key| key[0].chr.downcase + CAMELCASE.call(key)[1..-1] }
+      UPPERCASE = lambda { |key| key.upcase }
 
       FORMULAS = {
         :lower_camelcase => lambda { |key| LOWER_CAMELCASE.call(key) },
         :camelcase       => lambda { |key| CAMELCASE.call(key) },
+        :uppercase       => lambda { |key| UPPERCASE.call(key) },
         :none            => lambda { |key| key }
       }
 

--- a/spec/gyoku/xml_key_spec.rb
+++ b/spec/gyoku/xml_key_spec.rb
@@ -59,6 +59,11 @@ describe Gyoku::XMLKey do
       Gyoku::XMLKey.create(:snake_case).should == "SnakeCase"
     end
 
+    it "accepts :uppercase" do
+      Gyoku::XMLKey.symbol_converter = :uppercase
+      Gyoku::XMLKey.create(:snake_case).should == "SNAKE_CASE"
+    end
+
     it "accepts :none" do
       Gyoku::XMLKey.symbol_converter = :none
       Gyoku::XMLKey.create(:snake_Case).should == "snake_Case"


### PR DESCRIPTION
Thanks, @rubiii for writing and maintaining Savon! It's the first SOAP tool that I've actually been able to use in a complex Oralce/PeopleSoft environment.

This change would dramatically clean up our code; all of the Oracle web services we use have uppercase keys. Right now, it's a pain because we have to convert ActiveRecord attributes to uppercase strings.

Please consider.... Thanks!
