### PR TITLE
Remove development dependency version lock

### DIFF
--- a/gyoku.gemspec
+++ b/gyoku.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "builder", ">= 2.1.2"
 
-  s.add_development_dependency "rake",  "~> 0.9"
-  s.add_development_dependency "rspec", "~> 2.10"
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rspec"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
There's no need to lock development dependencies. When developing usually it's best to use latest versions and if there's non-backward compatible changes just fix code so it's up-to-date.
