### PR TITLE
Pass options to `Builder::XmlMarkup`

### DIFF
--- a/spec/gyoku/array_spec.rb
+++ b/spec/gyoku/array_spec.rb
@@ -51,6 +51,12 @@ describe Gyoku::Array do
 
       to_xml(array, "value", :escape_xml, :id => [1, 2]).should == result
     end
+
+    it "should pass options to XML Builder" do
+      array = [{ :name => "adam" }, { :name => "eve" }]
+      result = "<user>\n  <name>adam</name>\n</user>\n<user>\n  <name>eve</name>\n</user>\n"
+      to_xml(array, "user", true, {}, { :builder => {:indent => 2} }).should == result
+    end
   end
 
   def to_xml(*args)

--- a/spec/gyoku/hash_spec.rb
+++ b/spec/gyoku/hash_spec.rb
@@ -298,6 +298,12 @@ describe Gyoku::Hash do
         :attributes! => { :countries => { :array => true } }
       }
     end
+
+    it "should pass options to XML Builder" do
+      hash = {:some => { :new => "user" }}
+      result = "<some>\n  <new>user</new>\n</some>\n"
+      to_xml(hash, { :builder => {:indent => 2} }).should == result
+    end
   end
 
   it "doesn't modify original hash parameter by deleting its attribute keys" do


### PR DESCRIPTION
This PR adds option `:builder` which is directly passed to `Builder::XmlMarkup`
So it's possible to pass options like `:indent` and others. For example

``` ruby
Gyoku::xml({:some => { :new => "user" }}, {:builder => { :indent => 2} })
```

will produce

```
<some>
  <new>user</new>
</some>
```

To make indentation work correctly with `Builder` I had to make changes in that gem, so this won't work unless jimweirich/builder#44 is merged
