### PR TITLE
Allowing for order! to be a string key

### DIFF
--- a/lib/gyoku/hash.rb
+++ b/lib/gyoku/hash.rb
@@ -66,7 +66,7 @@ module Gyoku
     # Defaults to return the actual keys of the Hash if no :order! key could be found.
     # Raises an ArgumentError in case the :order! Array does not match the Hash keys.
     def self.order(hash)
-      order = hash[:order!]
+      order = hash[:order!] || hash.delete('order!')
       hash_without_order = hash.reject { |key, value| key == :order! }
       order = hash_without_order.keys unless order.kind_of? ::Array
 

--- a/spec/gyoku/hash_spec.rb
+++ b/spec/gyoku/hash_spec.rb
@@ -112,6 +112,22 @@ describe Gyoku::Hash do
       expect(to_xml(hash)).to eq(result)
     end
 
+    it "preserves the order of Hash keys and values specified through 'order!' (as a string key)" do
+      hash = { :find_user => { :name => "Lucy", :id => 666, 'order!' => [:id, :name] } }
+      result = "<findUser><id>666</id><name>Lucy</name></findUser>"
+      expect(to_xml(hash)).to eq(result)
+
+      hash = { :find_user => { :mname => "in the", :lname => "Sky", :fname => "Lucy", 'order!' => [:fname, :mname, :lname] } }
+      result = "<findUser><fname>Lucy</fname><mname>in the</mname><lname>Sky</lname></findUser>"
+      expect(to_xml(hash)).to eq(result)
+    end
+
+    it "uses :order! symbol values for ordering but leaves the string key 'order!' if both are present" do
+      hash = { :find_user => { :name => "Lucy", :id => 666, 'order!' => 'value', :order! => [:id, :name, 'order!'] } }
+      result = "<findUser><id>666</id><name>Lucy</name><order>value</order></findUser>"
+      expect(to_xml(hash)).to eq(result)
+    end
+
     it "raises if the :order! Array is missing Hash keys" do
       hash = { :name => "Lucy", :id => 666, :order! => [:name] }
       expect { to_xml(hash) }.to raise_error(ArgumentError, "Missing elements in :order! [:id]")


### PR DESCRIPTION
When using savon to issue SOAP requests in a background process, the
request parameters (a hash) get saved by resque in redis. When pulled
out of redis, all keys of the hash are stringified as they are
marshalled as strings.
In order to avoid ordering issues when using resque or sidekick, gyoku
will accept both the symbol or the string version of the order! key and
respect that order.
This way savon can take whatever comes from those backgrounding tools and convert it to XML without having to worry about deeply reconverting everything to symbols.
