### PR TITLE
Add option to unwrap array of hashes

### DIFF
--- a/lib/gyoku/array.rb
+++ b/lib/gyoku/array.rb
@@ -11,17 +11,27 @@ module Gyoku
     # Translates a given +array+ to XML. Accepts the XML +key+ to add the elements to,
     # whether to +escape_xml+ and an optional Hash of +attributes+.
     def self.to_xml(array, key, escape_xml = true, attributes = {}, options = {})
+
       self_closing = options.delete(:self_closing)
-      iterate_with_xml array, attributes do |xml, item, attrs, index|
+      unwrap = options[:unwrap] || false 
+
+      iterate_with_xml array, key, attributes, options do |xml, item, attrs, index|
         if self_closing
           xml.tag!(key, attrs)
-
         else
           case item
-            when ::Hash       then xml.tag!(key, attrs) { xml << Hash.to_xml(item, options) }
-            when ::Array      then xml.tag!(key, attrs) { xml << Array.to_xml(item, NESTED_ELEMENT_NAME) }
-            when NilClass     then xml.tag!(key, "xsi:nil" => "true")
-            else              xml.tag!(key, attrs) { xml << XMLValue.create(item, escape_xml) }
+            when ::Hash       then 
+              if unwrap
+                xml << Hash.to_xml(item, options)
+              else
+                xml.tag!(key, attrs) { xml << Hash.to_xml(item, options) }
+              end
+            when ::Array      then 
+              xml.tag!(key, attrs) { xml << Array.to_xml(item, NESTED_ELEMENT_NAME) }
+            when NilClass     then 
+              xml.tag!(key, "xsi:nil" => "true")
+            else              
+              xml.tag!(key, attrs) { xml << XMLValue.create(item, escape_xml) }
           end
         end
       end
@@ -31,8 +41,24 @@ module Gyoku
 
     # Iterates over a given +array+ with a Hash of +attributes+ and yields a builder +xml+
     # instance, the current +item+, any XML +attributes+ and the current +index+.
-    def self.iterate_with_xml(array, attributes)
+    def self.iterate_with_xml(array, key, attributes, options, &block)
+
       xml = Builder::XmlMarkup.new
+      unwrap = options[:unwrap] || false
+
+      if (unwrap)
+        xml.tag!(key) { iterate_array(xml, array, attributes, &block) }
+      else
+        iterate_array(xml, array, attributes, &block)
+      end
+
+      xml.target!
+    end
+
+
+    # Iterates over a given +array+ with a Hash of +attributes+ and yields a builder +xml+
+    # instance, the current +item+, any XML +attributes+ and the current +index+.
+    def self.iterate_array(xml, array, attributes, &block)
       array.each_with_index do |item, index|
         if item.respond_to?(:keys)
           attrs = item.reduce({}) do |st, v|
@@ -45,8 +71,8 @@ module Gyoku
         end
         yield xml, item, tag_attributes(attributes, index).merge(attrs), index
       end
-      xml.target!
     end
+
 
     # Takes a Hash of +attributes+ and the +index+ for which to return attributes
     # for duplicate tags.

--- a/spec/gyoku/array_spec.rb
+++ b/spec/gyoku/array_spec.rb
@@ -10,6 +10,13 @@ describe Gyoku::Array do
       expect(to_xml(array, "user")).to eq(result)
     end
 
+    it "returns the XML for an Array of Hashes unwrapped" do
+      array = [{ :name => "adam" }, { :name => "eve" }]
+      result = "<user><name>adam</name><name>eve</name></user>"
+
+      expect(to_xml(array, "user", true, {}, :unwrap => true)).to eq(result)
+    end
+
     it "returns the XML for an Array of different Objects" do
       array = [:symbol, "string", 123]
       result = "<value>symbol</value><value>string</value><value>123</value>"


### PR DESCRIPTION
Hi 

So, I was having a "small" issue with savon https://github.com/savonrb/savon/issues/672 that was in fact a Gyoku issue, already discussed here : https://github.com/savonrb/gyoku/issues/48

Turns out, @stgwilli did quite an awesome job on that last november and (correct me if I'm wrong, but I did check), never pull requested it. 

To make it simple, it allows array of hashes to be correctly formatted, **without breaking any previous behaviour**, as it is by adding an option (unwrap).

```
<items><item><name>foo</name></item></items><items><item><name>bar</name></item></items>
=>
<items><item><name>foo</name></item><item><name>bar</name></item></items>
```

It would be really nice to have this alternative, I'm pretty sure I'm not the only one who will have to switch to nokogiri otherwise (and that would pain me a great deal, as Gyoku is really great)