### PR TITLE
Support serializing arrays of 'gyoku' hashes. 

### DIFF
--- a/lib/gyoku/hash.rb
+++ b/lib/gyoku/hash.rb
@@ -15,12 +15,12 @@ module Gyoku
         xml_key = XMLKey.create key, options
 
         case
-          when :content! === key  then xml << XMLValue.create(value, escape_xml)
+          when :content! === key  then xml << XMLValue.create(value, escape_xml, options)
           when ::Array === value  then xml << Array.to_xml(value, xml_key, escape_xml, attributes, options.merge(:self_closing => self_closing))
           when ::Hash === value   then xml.tag!(xml_key, attributes) { xml << Hash.to_xml(value, options) }
           when self_closing       then xml.tag!(xml_key, attributes)
           when NilClass === value then xml.tag!(xml_key, "xsi:nil" => "true")
-          else                         xml.tag!(xml_key, attributes) { xml << XMLValue.create(value, escape_xml) }
+          else                         xml.tag!(xml_key, attributes) { xml << XMLValue.create(value, escape_xml, options) }
         end
       end
     end

--- a/lib/gyoku/xml_value.rb
+++ b/lib/gyoku/xml_value.rb
@@ -15,7 +15,7 @@ module Gyoku
       XS_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%Z"
 
       # Converts a given +object+ to an XML value.
-      def create(object, escape_xml = true)
+      def create(object, escape_xml = true, options = {})
         if Time === object
           object.strftime XS_TIME_FORMAT
         elsif DateTime === object
@@ -28,6 +28,8 @@ module Gyoku
           create object.to_datetime
         elsif object.respond_to?(:call)
           create object.call
+        elsif ::Hash === object
+          Gyoku::Hash.to_xml(object, options)
         else
           object.to_s
         end

--- a/spec/gyoku/xml_value_spec.rb
+++ b/spec/gyoku/xml_value_spec.rb
@@ -46,6 +46,11 @@ describe Gyoku::XMLValue do
       expect(create(object)).to eq("2012-03-22T16:22:33+00:00")
     end
 
+    it "hash objects get converted to xml" do
+      object = { document!: { "@version" => "2.0", content!: { key!: "value", other_key: { "@attribute" => 'value', content!: { key: "value" } } } } }
+      expect(create(object)).to eq("<document version=\"2.0\"><key>value</key><otherKey attribute=\"value\"><key>value</key></otherKey></document>")
+    end
+
     it "calls #to_s unless the Object responds to #to_datetime" do
       expect(create("value")).to eq("value")
     end


### PR DESCRIPTION
This change is intended to address the follow situation.

Calling `Gyoku.xml` with a hash containing an array of 'complex' hashes does not seem to serialize correctly.
```
# Non 'complex' seems to work
>> Gyoku.xml({ document!: [{ node: 'a' }] })
"<document><node>a</node></document>"

# 'complex' hashes do not :(
>> Gyoku.xml({ document!: [{ content!: { node1!: '1', node2!: '2' } }] })
"<document>{:node1!=>\"1\", :node2!=>\"2\"}</document>"
```

I would expect the following: 
```
>> Gyoku.xml({ document!: [{ content!: { node1!: '1', node2!: '2' } }] })
"<document><node1>1</node1><node2>2</node2></document>"
```
In order to get the desired output I added a case for handling `::Hash` objects in the `Gyoku::XMLValue` class. I also pass through options so the nested hashes are serialized correctly.

Am I missing any test cases that we need to ensure this wont break existing usages?