### PR TITLE
Allow unwrap option to whitelist keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Gyoku.xml({ :camel_case => "key" }, { :key_converter => :camelcase })
 # => "<CamelCase>key</CamelCase>"
 ```
 
+Custom key converters. You can use a lambda/Proc to provide customer key converters.
+This is a great way to leverage active support inflections for domain specific acronyms.
+
+``` ruby
+# Use camelize lower which will hook into active support if installed.
+Gyoku.xml({ acronym_abc: "value" }, key_converter: lambda { |key| key.camelize(:lower) })
+# => "<acronymABC>value</acronymABC>"
+
+```
+
 Hash key Strings are not converted and may contain namespaces.
 
 ``` ruby
@@ -150,6 +160,42 @@ Gyoku.xml(
     {:@name => "baz", :@some => "attr", :content! => 'rocks!'}
   ])
 # => "<foo name=\"bar\">gyoku</foo><foo name=\"baz\" some=\"attr\">rocks!</foo>"
+```
+
+Unwrapping Arrays. You can specify an optional `unwrap` argument to modify the default Array
+behavior. `unwrap` accepts a boolean flag (false by default) or an Array whitelist of keys to unwrap.
+``` ruby
+# Default Array behavior
+Gyoku.xml({
+  "foo" => [
+    {:is => 'great' },
+    {:is => 'awesome'}
+  ]
+})
+# => "<foo><is>great</is></foo><foo><is>awesome</is></foo>"
+
+# Unwrap Array behavior
+Gyoku.xml({
+  "foo" => [
+    {:is => 'great' },
+    {:is => 'awesome'}
+  ]
+}, unwrap: true)
+# => "<foo><is>great</is><is>awesome</is></foo>"
+
+# Unwrap Array, whitelist.
+# foo is not unwrapped, bar is.
+Gyoku.xml({
+  "foo" => [
+    {:is => 'great' },
+    {:is => 'awesome'}
+  ],
+  "bar" => [
+      {:is => 'rad' },
+      {:is => 'cool'}
+  ]
+}, unwrap: [:bar])
+# => "<foo><is>great</is></foo><foo><is>awesome</is></foo><bar><is>rad</is><is>cool</is></bar>"
 ```
 
 Naturally, it would ignore :content! if tag is self-closing:

--- a/lib/gyoku/array.rb
+++ b/lib/gyoku/array.rb
@@ -44,9 +44,9 @@ module Gyoku
     def self.iterate_with_xml(array, key, attributes, options, &block)
 
       xml = Builder::XmlMarkup.new
-      unwrap =  unwrap?(options[:unwrap], key)
+      unwrap =  unwrap?(options.fetch(:unwrap, false), key)
 
-      if (unwrap)
+      if unwrap
         xml.tag!(key) { iterate_array(xml, array, attributes, &block) }
       else
         iterate_array(xml, array, attributes, &block)

--- a/lib/gyoku/array.rb
+++ b/lib/gyoku/array.rb
@@ -13,7 +13,7 @@ module Gyoku
     def self.to_xml(array, key, escape_xml = true, attributes = {}, options = {})
 
       self_closing = options.delete(:self_closing)
-      unwrap = options[:unwrap] || false 
+      unwrap =  unwrap?(options.fetch(:unwrap, false), key)
 
       iterate_with_xml array, key, attributes, options do |xml, item, attrs, index|
         if self_closing
@@ -44,7 +44,7 @@ module Gyoku
     def self.iterate_with_xml(array, key, attributes, options, &block)
 
       xml = Builder::XmlMarkup.new
-      unwrap = options[:unwrap] || false
+      unwrap =  unwrap?(options[:unwrap], key)
 
       if (unwrap)
         xml.tag!(key) { iterate_array(xml, array, attributes, &block) }
@@ -83,6 +83,10 @@ module Gyoku
         value = value[index] if value.kind_of? ::Array
         value ? hash.merge(key => value) : hash
       end
+    end
+
+    def self.unwrap?(unwrap, key)
+      unwrap.kind_of?(::Array) ? unwrap.include?(key.to_sym) : unwrap
     end
 
   end


### PR DESCRIPTION
Recently [this PR](https://github.com/savonrb/gyoku/pull/52) was merged to allow unwrapping of arrays. This capability is awesome and I am excited it landed. However, I recently had a use case that required me to unwrap only certain keys. These changes support whitelisting keys to unwrap. The option supports either an array of keys (symbols) to unwrap or a boolean value for wholesale unwrap/wrap behavior. 

Unwrapping Arrays. You can specify an optional `unwrap` argument to modify the default Array
behavior. `unwrap` accepts a boolean flag (false by default) or an Array whitelist of keys to unwrap.
``` ruby
# Default Array behavior
Gyoku.xml({
  "foo" => [
    {:is => 'great' },
    {:is => 'awesome'}
  ]
})
# => "<foo><is>great</is></foo><foo><is>awesome</is></foo>"

# Unwrap Array behavior
Gyoku.xml({
  "foo" => [
    {:is => 'great' },
    {:is => 'awesome'}
  ]
}, unwrap: true)
# => "<foo><is>great</is><is>awesome</is></foo>"

# Unwrap Array, whitelist.
# foo is not unwrapped, bar is.
Gyoku.xml({
  "foo" => [
    {:is => 'great' },
    {:is => 'awesome'}
  ],
  "bar" => [
      {:is => 'rad' },
      {:is => 'cool'}
  ]
}, unwrap: [:bar])
# => "<foo><is>great</is></foo><foo><is>awesome</is></foo><bar><is>rad</is><is>cool</is></bar>"
```

Thanks for this awesome Gem. If you have any concerns with overloading this option I am open to any suggestions. I added some doc to the readme, I included a section on the new(er) `key_converter` functionality as it is something I found useful that wasn't included. 
