### PR TITLE
Array.iterate_with_xml applies attributes even when `unwrap: true`

### DIFF
--- a/lib/gyoku/array.rb
+++ b/lib/gyoku/array.rb
@@ -47,7 +47,7 @@ module Gyoku
       unwrap = options[:unwrap] || false
 
       if (unwrap)
-        xml.tag!(key) { iterate_array(xml, array, attributes, &block) }
+        xml.tag!(key, attributes) { iterate_array(xml, array, attributes, &block) }
       else
         iterate_array(xml, array, attributes, &block)
       end

--- a/spec/gyoku/array_spec.rb
+++ b/spec/gyoku/array_spec.rb
@@ -45,6 +45,17 @@ describe Gyoku::Array do
       expect(to_xml(array, "value", :escape_xml, :active => true)).to eq(result)
     end
 
+    it "unwrap: true allows attributes to be set" do
+      array = [{:item=>"abc"}]
+      key = "items"
+      escape_xml = :escape_xml
+      attributes = { "amount"=>"1" }
+      options = { :unwrap=>true }
+      result = "<items amount=\"1\"><item>abc</item></items>"
+
+      expect(to_xml(array, key, escape_xml, attributes, options)).to eq result
+    end
+
     it "adds attributes to duplicate tags" do
       array = ["adam", "eve"]
       result = '<value id="1">adam</value><value id="2">eve</value>'


### PR DESCRIPTION
This is an attempt to address #56.

@drakmail, @tjarratt please see if this is any good and doesn't break anything.
