### PR TITLE
CI: Drop unused Travis sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: "ruby"
-sudo: false
 script: "bundle exec rake"
 rvm:
   - 2.0.0


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).