### PR TITLE
gemspec: Drop the executables directive

### DIFF
--- a/gyoku.gemspec
+++ b/gyoku.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
This gem includes no executables, this PR simplifies the gemspec.