### PR TITLE
gemspec: Drop defunct rubyforge_project directive

### DIFF
--- a/gyoku.gemspec
+++ b/gyoku.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.description = "Gyoku translates Ruby Hashes to XML"
   s.required_ruby_version = '>= 1.9.2'
 
-  s.rubyforge_project = "gyoku"
   s.license = "MIT"
 
   s.add_dependency "builder", ">= 2.1.2"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

Background: 

- RubyForge was closed down in 2013, https://twitter.com/evanphx/status/399552820380053505
- rubygems/rubygems#2436 deprecated the `rubyforge_project` property