### PR TITLE
gemspec: Add rexml as a gem dependency

### DIFF
--- a/gyoku.gemspec
+++ b/gyoku.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.add_dependency "builder", ">= 2.1.2"
+  s.add_dependency "rexml", "~> 3.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
In Ruby 3.0.0, rexml was turned into a gem dependency.

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

See #70 