### PR TITLE
Gemfile: remove unused Rubinius gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,6 @@
 source 'https://rubygems.org'
+
 gemspec
 
 gem 'simplecov', :require => false
 gem 'coveralls', :require => false
-
-platform :rbx do
-  gem 'json'
-  gem 'racc'
-  gem 'rubysl'
-  gem 'rubinius-coverage'
-end


### PR DESCRIPTION
In #73, Rubinius was removed from the build matrix, this drops the supporting gems from the Gemfile.

This failed #77 