### PR TITLE
Encapsulate check for explicit attribute

### DIFF
--- a/lib/gyoku/array.rb
+++ b/lib/gyoku/array.rb
@@ -66,7 +66,7 @@ module Gyoku
         attrs = if item.respond_to?(:keys)
           item.each_with_object({}) do |v, st|
             k = v[0].to_s
-            st[k[1..]] = v[1].to_s if k.start_with?("@")
+            st[k[1..]] = v[1].to_s if Hash.explicit_attribute?(k)
           end
         else
           {}

--- a/spec/gyoku/hash_spec.rb
+++ b/spec/gyoku/hash_spec.rb
@@ -409,6 +409,22 @@ describe Gyoku::Hash do
     expect(hash).to eq({person: {name: "Johnny", surname: "Bravo", "@xsi:type": "People"}})
   end
 
+  describe ".explicit_attribute?" do
+    subject { described_class.explicit_attribute?(key) }
+
+    context "when key starts with an @" do
+      let(:key) { "@" }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when key does not start with an @" do
+      let(:key) { "NOT@" }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
   def to_xml(hash, options = {})
     Gyoku::Hash.to_xml hash, options
   end


### PR DESCRIPTION
Instead of looking for strings that begin with `@` several times throughout the library, this check is now encapsulated in one place.