### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   test:
@@ -16,16 +10,20 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - '3.2'
-          - '3.1'
           - '3.0'
-          - 'jruby'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
+          - '4.0'
+          - 'head'
+          - jruby-9.4.8
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
@@ -42,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/gyoku.gemspec
+++ b/gyoku.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "standard"
 
-  s.files = `git ls-files`.split("\n")
+  s.files = `git ls-files lib`.split($/) + ["CHANGELOG.md", "MIT-LICENSE", "README.md"]
 
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar.gz

$ git switch reduce-gem-size

$ gem build -o after.tar.gz

$ du -sh before.tar.gz after.tar.gz
 20K 	before
 16K 	after
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 20K    | 16K   | −4K (⏷ −20.00%)      |


###  whitch files was deleted?

```diff
 data
-├── .github
-│   └── workflows
-│       └── ci.yml
-├── .gitignore
-├── .rspec
 ├── CHANGELOG.md
-├── Gemfile
-├── gyoku.gemspec
 ├── lib
 │   ├── gyoku
 │   │   ├── array.rb
 │   │   ├── hash.rb
 │   │   ├── prettifier.rb
 │   │   ├── version.rb
 │   │   ├── xml_key.rb
 │   │   └── xml_value.rb
 │   └── gyoku.rb
 ├── MIT-LICENSE
-├── Rakefile
 ├── README.md
-└── spec
-    ├── gyoku
-    │   ├── array_spec.rb
-    │   ├── hash_spec.rb
-    │   ├── prettifier_spec.rb
-    │   ├── xml_key_spec.rb
-    │   └── xml_value_spec.rb
-    ├── gyoku_spec.rb
-    └── spec_helper.rb
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)