### PR TITLE
Harden CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a bug report
+
+---
+
+<!-- Please don't delete this template or we'll close your issue -->
+<!-- Before creating an issue, please ensure you are using the latest version of gyoku. -->
+
+# Bug report
+
+**Current behavior:**
+
+
+**Ruby hash input and the XML you got back:**
+
+<!-- The Ruby hash you passed to Gyoku.xml and the XML string it returned. -->
+
+**Expected behavior:**
+
+<!-- The XML you expected instead. -->
+
+**Steps to reproduce current behavior:**
+
+
+**System information:**
+
+* ruby version: 
+* gyoku version: 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest a new feature for gyoku
+
+---
+
+<!-- Please don't delete this template or we'll close your issue -->
+
+## Feature request
+
+<!-- Issues which contain questions or support requests will be closed. -->
+
+**Motivation for this feature:**
+
+<!-- Please describe the use case or problem this would solve. -->
+
+**Proposed implementation:**
+
+<!-- Please describe at least one proposed implementation design. -->
+
+**Would this introduce a breaking change?**
+
+<!-- If yes, please describe the impact and a migration path for existing applications. -->
+
+**Are you willing to work on this yourself?**
+yes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+**What kind of change is this?**
+
+<!-- E.g. a bugfix, feature, refactoring, build change, etc… -->
+
+**Did you add tests for your changes?**
+
+<!-- Note that we won't merge your changes if you don't add tests -->
+
+**Summary of changes**
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
+
+**Other information**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,60 +1,84 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  - push
+  - pull_request
+
+permissions:
+  contents: read # checkout only, nothing else
 
 jobs:
-  test:
-    name: Ruby ${{ matrix.ruby }}
-
-    strategy:
-      fail-fast: true
-      matrix:
-        ruby:
-          - '3.0'
-          - '3.1'
-          - '3.2'
-          - '3.3'
-          - '3.4'
-          - '4.0'
-          - 'head'
-          - jruby-9.4.8
-
+  audit:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Audit dependencies
+        run: bundle exec bundle-audit check --update
+      - name: Audit Ruby runtime
+        # CVE-2026-41316 is an ERB flaw fixed in Ruby 4.0.3 and not yet backported.
+        # Ignored on affected rubies only. See:
+        # https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316/
+        # https://github.com/advisories/GHSA-q339-8rmv-2mhv
+        run: |
+          ignore=""
+          if ruby -e 'exit 1 unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new("4.0.3")'; then
+            ignore="--ignore CVE-2026-41316"
+          fi
+          bundle exec ruby-audit check $ignore
 
-      - name: Install Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false # fail the build on findings instead of uploading SARIF
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Standard
+        run: bundle exec standardrb
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', 3.1, 3.2, 3.3, 3.4, '4.0', truffleruby, head, truffleruby-head, jruby-9.4.8]
+    # Head builds exist to surface upstream regressions early.
+    # They should not block the build.
+    continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'truffleruby-head' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true # 'bundle install' and cache
-
+          bundler-cache: true # bundle installs and caches dependencies
       - name: Run tests
         run: bundle exec rake --trace
-        continue-on-error: false
-
-  coveralls:
-    name: Coveralls
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Upload coverage to Coveralls
+        if: matrix.ruby == '3.4'
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
-          ruby-version: 3.2
-          bundler-cache: true
-
-      - name: Install dependencies
-        run: bundle install
-
-      - name: Run tests
-        run: bundle exec rake
-
-      - name: Report coverage
-        uses: coverallsapp/github-action@v2
-        with:
-          flag-name: ruby-3.2
+          file: coverage/.resultset.json
+          format: simplecov

--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -1,0 +1,22 @@
+name: Push gem
+on:
+  release:
+    types: [published]
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: release
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3"
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contribution Guide
+
+This page describes how to contribute changes to Gyoku.
+
+Please do not create a pull request without reading this guide first.
+
+**Bug fixes**
+
+Gyoku turns a Ruby hash into an XML string. If you think you found a bug, the most useful
+input you can give us is: the Ruby hash you passed to `Gyoku.xml` (with any options), the
+XML you got back, and the XML you expected. You're a developer, we are developers, and you
+know we need a test to reproduce a problem and make sure it does not come back.
+
+So if you can reproduce your problem in a spec, that would be awesome! Please include the
+options you passed, because behavior often depends on them (`:key_converter`, `:unwrap`,
+`:element_form_default`, and friends).
+
+After we have a failing spec, it needs to be fixed. Make sure your new spec is the only failing
+one under the `spec` directory.
+
+**Running tests**
+
+```bash
+bundle install
+bundle exec rspec
+```
+
+Before opening a pull request, also run the checks CI runs so you don't get a red build:
+
+```bash
+bundle exec standardrb
+```
+
+Please follow this workflow for Pull Requests:
+
+* [Fork the project](https://help.github.com/articles/fork-a-repo)
+* Create a feature branch and make your bug fix
+* Add tests for it!
+* [Send a Pull Request](https://help.github.com/articles/using-pull-requests)
+* [Check that your Pull Request passes the build](https://github.com/savonrb/gyoku/actions/workflows/ci.yml)
+
+**Improvements and feature requests**
+
+If you have an idea for an improvement or a new feature, please feel free to
+[create a new Issue](https://github.com/savonrb/gyoku/issues/new/choose) and describe your idea
+so that other people can give their insights and opinions. This is also important to avoid
+duplicate work.
+
+Pull Requests and Issues on GitHub are meant to be used to discuss problems and ideas, so please
+make sure to participate and follow up on questions. In case no one comments on your ticket,
+please keep updating the ticket with additional information.

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "bundler-audit", "~> 0.9.3", require: false
+# ruby_audit 3.x requires Ruby >= 3.1. Only the CI audit job needs it.
+gem "ruby_audit", "~> 3.1", require: false if RUBY_VERSION >= "3.1.0"
 gem "simplecov", require: false
 gem "coveralls", require: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+_You'll need write access to the repository to create a release. Publishing is handled automatically via [trusted publishing](https://guides.rubygems.org/trusted-publishing/)._
+
+## Cutting a release
+
+1. On your release branch (e.g. `main`), edit [CHANGELOG.md](https://github.com/savonrb/gyoku/blob/main/CHANGELOG.md) to finalize the new version number and list of all changes.
+2. Bump [version.rb](https://github.com/savonrb/gyoku/blob/main/lib/gyoku/version.rb) to the version you picked in previous step.
+3. **Final check**: make sure all tests are green, and that `rake build` succeeds. If not, merge any fixes back to the release branch and go to step 1.
+4. [Draft a new release](https://github.com/savonrb/gyoku/releases/new) on Github.
+   - In the "Choose a tag" field, type the version tag - e.g. `v1.4.1` - and select "Create new tag on publish".
+   - Use `v[version]` for the release title, and copy the changelog into the release notes.
+   - Click "Publish release". Github creates and pushes the tag, which triggers the release workflow.
+5. Publishing to RubyGems.org is fully automated. The [Push gem workflow](https://github.com/savonrb/gyoku/actions/workflows/gem_push.yml) triggers on the published release and requires approval from a release manager via the `release` environment before credentials are issued. **Before approving**: confirm that CI is green on the release commit. Approve the deployment in the Actions UI and the gem will be built and pushed automatically.
+
+## Updating minimum ruby version
+
+- Update `required_ruby_version` in [gyoku.gemspec](https://github.com/savonrb/gyoku/blob/main/gyoku.gemspec)
+- Update the test matrix in [ci.yml](https://github.com/savonrb/gyoku/blob/main/.github/workflows/ci.yml)
+- Update [README](https://github.com/savonrb/gyoku/blob/main/README.md) with the correct support matrix
+- Note the updated requirement in [CHANGELOG.md](https://github.com/savonrb/gyoku/blob/main/CHANGELOG.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the latest 1.x release.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.4.x   | :white_check_mark: |
+| < 1.4   | :x:                |
+
+If you are on an older release, upgrade to the latest 1.x before reporting.
+
+## Reporting a vulnerability
+
+Please do not report security issues through public GitHub issues.
+
+Instead, [report a vulnerability privately](https://github.com/savonrb/gyoku/security/advisories/new)
+through GitHub. You will get an acknowledgement within 7 days. Please keep the
+report confidential until a fix is released.
+
+## Scope
+
+This policy covers the gyoku gem, the request builder used by the savon SOAP
+client to translate Ruby hashes into XML. For issues in another gem in the
+family (akami, httpi, nori, savon, wasabi), report to the affected repository
+in the [savonrb organization](https://github.com/savonrb). If you are not sure
+which gem is affected, report it here.

--- a/gyoku.gemspec
+++ b/gyoku.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.license = "MIT"
 
+  s.metadata["rubygems_mfa_required"] = "true"
+
   s.add_dependency "builder", ">= 2.1.2"
   s.add_dependency "rexml", "~> 3.0"
 

--- a/lib/gyoku/xml_key.rb
+++ b/lib/gyoku/xml_key.rb
@@ -16,7 +16,7 @@ module Gyoku
       def create(key, options = {})
         xml_key = chop_special_characters key.to_s
 
-        if unqualified = unqualify?(xml_key)
+        if (unqualified = unqualify?(xml_key))
           xml_key = xml_key.split(":").last
         end
 


### PR DESCRIPTION
Brings gyoku to parity with the hardening done in savon and nori.

* Adds a dependency/runtime audit job (bundle-audit + ruby-audit), a zizmor workflow audit, and a standardrb lint job alongside the test matrix.
* Actions pinned by SHA, top-level permissions set to `contents: read`, and checkouts run with `persist-credentials: false`.
* Adds truffleruby and truffleruby-head. Tolerates head builds with `continue-on-error`.
* New `gem_push.yml` publishes on release via rubygems trusted publishing. Documented in `RELEASING.md`.
* Gemspec now sets `rubygems_mfa_required`.
* Weekly github-actions updates with a 7-day cooldown, so the SHA pins stay fresh.
* Adds `SECURITY.md`, `CONTRIBUTING.md`, issue templates, and a PR template.