### PR TITLE
CI: use JRuby 9.4.15 to get to green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', 3.1, 3.2, 3.3, 3.4, '4.0', truffleruby, head, truffleruby-head, jruby-9.4.8]
+        ruby: ['3.0', 3.1, 3.2, 3.3, 3.4, '4.0', truffleruby, head, truffleruby-head, jruby-9.4.15]
     # Head builds exist to surface upstream regressions early.
     # They should not block the build.
     continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'truffleruby-head' }}


### PR DESCRIPTION


**What kind of change is this?**

Build fix attempt for JRuby.

**Did you add tests for your changes?**

No, the CI was red.

**Summary of changes**

We had some boring CI failures:

```
bundler: failed to load command: rake (/home/runner/work/gyoku/gyoku/vendor/bundle/jruby/3.1.0/bin/rake)
Gem::LoadError: You have already activated jar-dependencies 0.4.1, but your Gemfile requires jar-dependencies 0.5.7. Since jar-dependencies is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports jar-dependencies as a default gem.
```

Trying to upgrade to see whether this goes away.